### PR TITLE
Fix declaration of dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ import influxdb_metrics as app
 
 install_requires = [
     'django>=1.6',
-    'influxdb @ git+https://github.com/influxdata/influxdb-python@cc41e290f690c4eb67f75c98fa9f027bdb6eb16b#egg=influxdb'
+    'influxdb @ git+https://github.com/influxdata/influxdb-python@cc41e290f690c4eb67f75c98fa9f027bdb6eb16b#egg=influxdb',
     'tld',
     'python-server-metrics>=0.1.9',
 ]


### PR DESCRIPTION
The missing comma was causing it to resolve as "influxdbtld", and giving me errors like:

```
ERROR: Requested influxdb from git+https://github.com/influxdata/influxdb-python@cc41e290f690c4eb67f75c98fa9f027bdb6eb16b#egg=influxdbtld (from -r /tmp/tmp15az13uy (line 73)) has different name in metadata: 'influxdb'
```

This only happened after upgrading to python 3.9.0 so maybe something changed there, but it doesn't really make sense to me as python 3.7 and 3.9 (and presumably 3.8) do this:

```python
Python 3.7.3 (default, Jul 25 2020, 13:03:44) 
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> a = [
... 'foo'
... 'bar'
... ]
>>> a
['foobar']
```

```python
Python 3.9.0 (default, Oct  7 2020, 23:09:01) 
[GCC 10.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> a = [
... 'foo'
... 'bar'
... ]
>>> a
['foobar']
```